### PR TITLE
Removed superfluous SDL2/ from the #includes in helpers.c

### DIFF
--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -1,5 +1,5 @@
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_mixer.h"
+#include "SDL.h"
+#include "SDL_mixer.h"
 
 // These were all macros in SDL_mixer.h.
 


### PR DESCRIPTION
The "SDL2/" part caused the linker to not find the SDL libraries themselves. After removing them from helpers.c, the compiler had no problems. It happened on a MINGW64 system.