### PR TITLE
Replace monad-control/lifted-base with unliftio

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,5 @@
+Upcoming
+=======
+
+* Replace `monad-control` and `lifted-base` dependencies with `unliftio-core`
+  and `unliftio`

--- a/sdl2-mixer.cabal
+++ b/sdl2-mixer.cabal
@@ -46,10 +46,10 @@ library
     base               >= 4.7 && < 5,
     bytestring         >= 0.10.4.0,
     data-default-class >= 0.0.1,
-    lifted-base        >= 0.2,
-    monad-control      >= 1.0,
     sdl2               >= 2.0.0,
     template-haskell,
+    unliftio-core,
+    unliftio,
     vector             >= 0.10
 
   default-language:

--- a/src/SDL/Mixer.hs
+++ b/src/SDL/Mixer.hs
@@ -167,10 +167,9 @@ module SDL.Mixer
   ) where
 
 import Control.Exception (throwIO)
-import Control.Exception.Lifted (finally)
 import Control.Monad (void, forM, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Bits ((.|.), (.&.))
 import Data.ByteString (ByteString, readFile)
 import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
@@ -192,6 +191,7 @@ import SDL (SDLException(SDLCallFailed))
 import SDL.Internal.Exception
 import SDL.Raw.Filesystem (rwFromConstMem)
 import System.IO.Unsafe (unsafePerformIO)
+import UnliftIO.Exception (finally)
 
 import qualified SDL.Raw
 import qualified SDL.Raw.Mixer
@@ -243,7 +243,7 @@ version = liftIO $ do
 --
 -- Automatically cleans up the API when the inner computation finishes.
 withAudio
-  :: (MonadBaseControl IO m, MonadIO m) => Audio -> ChunkSize -> m a -> m a
+  :: MonadUnliftIO m => Audio -> ChunkSize -> m a -> m a
 withAudio conf csize act = do
   openAudio conf csize
   finally act closeAudio


### PR DESCRIPTION
Here's a patch if you want it, replacing `monad-control` with `unliftio`. Cheers.